### PR TITLE
Fix segfault in error case

### DIFF
--- a/prov/zhpe/include/zhpe.h
+++ b/prov/zhpe/include/zhpe.h
@@ -1571,8 +1571,11 @@ static inline void zhpe_rstate_release(struct zhpe_iov_state *rstate)
 	struct zhpe_iov		*ziov = rstate->viov;
 	int			i;
 
-	for (i = 0; i < rstate->cnt; i++)
+	for (i = 0; i < rstate->cnt; i++) {
+		if (rstate->missing & (1U << i))
+			continue;
 		zhpe_rkey_put(ziov[i].iov_rkey);
+	}
 }
 
 static inline void

--- a/prov/zhpe/src/zhpe_progress.c
+++ b/prov/zhpe/src/zhpe_progress.c
@@ -880,6 +880,7 @@ static inline int zhpe_pe_rem_setup(struct zhpe_conn *conn,
 			break;
 		}
 	}
+	rstate->missing = missing;
 
 	return ret;
 }


### PR DESCRIPTION
If there was a failure to get the remote key, a bad pointer
would be passed rkey_put().

Signed-off-by: John Byrne <john.l.byrne@hpe.com>